### PR TITLE
modernize policies and external GnuPG configuration

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -17,7 +17,6 @@ papp.desc = ${app.name} portable on Windows by Portapps
 papp.url = https://github.com/portapps/${papp.id}
 papp.folder = app
 
-papp.gnupg.url = https://www.gnupg.org/ftp/gcrypt/binary/gnupg-w32-2.5.19_20260424.exe
 papp.languages = ar,ast,be,bg,br,ca,cak,cs,cy,da,de,dsb,el,en-GB,es-AR,es-ES,et,eu,fi,fr,fy-NL,ga-IE,gd,gl,he,hr,hsb,hu,hy-AM,id,is,it,ja,ka,kab,kk,ko,lt,ms,nb-NO,nl,nn-NO,pl,pt-BR,pt-PT,rm,ro,ru,sk,sl,sq,sr,sv-SE,tr,uk,uz,vi,zh-CN,zh-TW
 
 # Official artifacts

--- a/build.xml
+++ b/build.xml
@@ -33,16 +33,6 @@
       <fileset dir="${tmp.path}\extract2" defaultexcludes="no"/>
     </move>
 
-    <echo message="Downloading GnuPG..."/>
-    <property name="gnupg.file" location="${tmp.path}\gnupg-setup.exe"/>
-    <get dest="${gnupg.file}" src="${papp.gnupg.url}" skipexisting="false" verbose="on"/>
-
-    <echo message="Extracting GnuPG..."/>
-    <sevenzip-x src="${gnupg.file}" dest="${extract.path}\gnupg"/>
-    <delete dir="${extract.path}\gnupg\$PLUGINSDIR"/>
-    <delete file="${extract.path}\gnupg\gnupg-uninstall.exe.nsis"/>
-    <assertfile file="${extract.path}\gnupg\bin\gpg.exe"/>
-
     <echo message="Downloading additional languages..."/>
     <property name="papp.languages.path" location="${extract.path}\langs"/>
     <mkdir dir="${papp.languages.path}"/>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/portapps/stormhen-portable
 go 1.26.0
 
 require (
-	github.com/Jeffail/gabs v1.4.0
 	github.com/pierrec/lz4/v3 v3.3.5
 	github.com/pkg/errors v0.9.1
 	github.com/portapps/portapps/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 code.cloudfoundry.org/bytefmt v0.0.0-20190710193110-1eb035ffe2b6/go.mod h1:wN/zk7mhREp/oviagqUXY3EwuHhWyOvAdsn5Y4CzOrc=
-github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
-github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/akavel/rsrc v0.10.2 h1:Zxm8V5eI1hW4gGaYsJQUhxpjkENuG91ki8B4zCrvEsw=
 github.com/akavel/rsrc v0.10.2/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -2,16 +2,14 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
 
-	"github.com/Jeffail/gabs"
 	"github.com/pkg/errors"
 	"github.com/portapps/portapps/v3"
 	"github.com/portapps/portapps/v3/pkg/log"
@@ -21,11 +19,13 @@ import (
 )
 
 type config struct {
-	Cleanup           bool   `yaml:"cleanup" mapstructure:"cleanup"`
-	MultipleInstances bool   `yaml:"multiple_instances" mapstructure:"multiple_instances"`
-	DisableTelemetry  bool   `yaml:"disable_telemetry" mapstructure:"disable_telemetry"`
-	GnuPGAgentPath    string `yaml:"gnupg_agent_path" mapstructure:"gnupg_agent_path"`
-	Locale            string `yaml:"locale" mapstructure:"locale"`
+	Cleanup              bool   `yaml:"cleanup" mapstructure:"cleanup"`
+	MultipleInstances    bool   `yaml:"multiple_instances" mapstructure:"multiple_instances"`
+	DisableTelemetry     bool   `yaml:"disable_telemetry" mapstructure:"disable_telemetry"`
+	DisableCrashReporter bool   `yaml:"disable_crash_reporter" mapstructure:"disable_crash_reporter"`
+	GnuPGHome            string `yaml:"gnupg_home" mapstructure:"gnupg_home"`
+	GnuPGPath            string `yaml:"gnupg_path" mapstructure:"gnupg_path"`
+	Locale               string `yaml:"locale" mapstructure:"locale"`
 }
 
 var (
@@ -33,20 +33,18 @@ var (
 	cfg *config
 )
 
-const (
-	embeddedGnupgAgentPath = `app\gnupg\bin\gpg.exe`
-	defaultLocale          = "en-US"
-)
+const defaultLocale = "en-US"
 
 func init() {
 	var err error
 
 	// Default config
 	cfg = &config{
-		Cleanup:           false,
-		MultipleInstances: false,
-		DisableTelemetry:  false,
-		Locale:            defaultLocale,
+		Cleanup:              false,
+		MultipleInstances:    false,
+		DisableTelemetry:     false,
+		DisableCrashReporter: true,
+		Locale:               defaultLocale,
 	}
 
 	// Init app
@@ -62,25 +60,28 @@ func main() {
 
 	app.Process = filepath.Join(app.AppPath, "thunderbird.exe")
 	app.Args = []string{
-		"--profile",
+		"-profile",
 		profileFolder,
 	}
 
 	// Set env vars
 	crashreporterFolder := utl.CreateFolder(app.DataPath, "crashreporter")
 	pluginsFolder := utl.CreateFolder(app.DataPath, "plugins")
-	os.Setenv("MOZ_CRASHREPORTER", "0")
 	os.Setenv("MOZ_CRASHREPORTER_DATA_DIRECTORY", crashreporterFolder)
-	os.Setenv("MOZ_CRASHREPORTER_DISABLE", "1")
-	os.Setenv("MOZ_CRASHREPORTER_NO_REPORT", "1")
-	os.Setenv("MOZ_DATA_REPORTING", "0")
 	os.Setenv("MOZ_MAINTENANCE_SERVICE", "0")
 	os.Setenv("MOZ_PLUGIN_PATH", pluginsFolder)
 	os.Setenv("MOZ_UPDATER", "0")
+	if cfg.DisableCrashReporter {
+		os.Setenv("MOZ_CRASHREPORTER", "0")
+		os.Setenv("MOZ_CRASHREPORTER_DISABLE", "1")
+		os.Setenv("MOZ_CRASHREPORTER_NO_REPORT", "1")
+	}
+	if cfg.DisableTelemetry {
+		os.Setenv("MOZ_DATA_REPORTING", "0")
+	}
 
 	// Create and check mutex
 	mu, err := mutex.Create(app.ID)
-	defer mutex.Release(mu)
 	if err != nil {
 		if !cfg.MultipleInstances {
 			log.Error().Msg("You have to enable multiple instances in your configuration if you want to launch another instance")
@@ -94,13 +95,15 @@ func main() {
 		} else {
 			log.Warn().Msg("Another instance is already running")
 		}
+	} else {
+		defer mutex.Release(mu)
 	}
 
 	// Cleanup on exit
 	if cfg.Cleanup {
 		defer func() {
 			utl.Cleanup([]string{
-				path.Join(os.Getenv("APPDATA"), "Thunderbird"),
+				filepath.Join(os.Getenv("APPDATA"), "Thunderbird"),
 			})
 		}()
 	}
@@ -111,30 +114,24 @@ func main() {
 		log.Error().Err(err).Msg("Cannot set locale")
 	}
 
-	// GnuPG agent
-	var gnupgAgentPath string
-	log.Info().Msg("Seeking GnuPG Agent path...")
-	if cfg.GnuPGAgentPath != "" {
-		gnupgAgentPath = cfg.GnuPGAgentPath
-		log.Info().Msgf("Getting GnuPG Agent from YAML cfg: %s", gnupgAgentPath)
-	} else if gnupgAgentPath, err = exec.LookPath("gpg.exe"); err == nil {
-		log.Info().Msgf("Getting GnuPG Agent from PATH: %s", gnupgAgentPath)
-	} else {
-		gnupgAgentPath = filepath.Join(app.RootPath, embeddedGnupgAgentPath)
-		log.Info().Msgf("Getting embedded GnuPG Agent: %s", gnupgAgentPath)
+	// GnuPG
+	gnupgHome := cfg.GnuPGHome
+	if gnupgHome == "" {
+		gnupgHome = os.Getenv("GNUPGHOME")
 	}
-	if gnupgAgentPath != "" {
-		gnupgAgentPath = strings.Replace(strings.Replace(gnupgAgentPath, `/`, `\`, -1), `\`, `\\`, -1)
+	if gnupgHome != "" {
+		os.Setenv("GNUPGHOME", gnupgHome)
 	}
+	gnupgPath := cfg.GnuPGPath
 
 	// Multiple instances
 	if cfg.MultipleInstances {
 		log.Info().Msg("Multiple instances enabled")
-		app.Args = append(app.Args, "--no-remote")
+		app.Args = append(app.Args, "-no-remote")
 	}
 
 	// Policies
-	if err := createPolicies(); err != nil {
+	if err := createPolicies(locale); err != nil {
 		log.Fatal().Err(err).Msg("Cannot create policies")
 	}
 
@@ -154,65 +151,43 @@ pref("general.config.obscure_value", 0);`); err != nil {
 		log.Fatal().Err(err).Msg("Cannot create portapps.cfg")
 	}
 	mozillaCfgData := struct {
-		Telemetry      string
-		GnuPgAgentPath string
-		Locale         string
+		DisableCrashReporter bool
+		HasGnuPGPath         bool
+		GnuPGPath            string
+		Locale               string
 	}{
-		strconv.FormatBool(!cfg.DisableTelemetry),
-		gnupgAgentPath,
-		locale,
+		cfg.DisableCrashReporter,
+		gnupgPath != "",
+		strconv.Quote(gnupgPath),
+		strconv.Quote(locale),
 	}
-	mozillaCfgTpl := template.Must(template.New("mozillaCfg").Parse(`// Disable updater
-lockPref("app.update.enabled", false);
-lockPref("app.update.auto", false);
-lockPref("app.update.mode", 0);
-lockPref("app.update.service.enabled", false);
+	mozillaCfgTpl := template.Must(template.New("mozillaCfg").Parse(`// Portable defaults only.
 
-// Set locale
-pref("intl.locale.requested", "{{ .Locale }}");
+// Locale fallback. Prefer policies.json RequestedLocales for modern Thunderbird.
+pref("intl.locale.requested", {{ .Locale }});
 
-// Extensions scopes
-lockPref("extensions.enabledScopes", 4);
-lockPref("extensions.autoDisableScopes", 3);
-
-// Disable check default client
-lockPref("mail.shell.checkDefaultClient", false);
-
-// Disable WinSearch integration
-lockPref("mail.winsearch.enable", false);
-lockPref("mail.winsearch.firstRunDone", true);
-
-// Disable Add-ons compatibility checking
-clearPref("extensions.lastAppVersion");
-
-// Don't show 'know your rights' on first run
+// Keep first-run noise down.
 pref("browser.rights.3.shown", true);
 pref("mail.rights.version", 1);
 
-// Disable start page
-lockPref("mailnews.start_page.enabled", false);
+{{ if .HasGnuPGPath -}}
+// Use external OpenPGP GnuPG.
+pref("mail.openpgp.allow_external_gnupg", true);
+pref("mail.openpgp.alternative_gpg_path", {{ .GnuPGPath }});
+pref("mail.openpgp.fetch_pubkeys_from_gnupg", true);
 
-// Disable calendar notification
-lockPref("calendar.integration.notify", false);
-
-// Don't show WhatsNew on first run after every update
-pref("mailnews.start_page_override.mstone", "ignore");
-
-// Disable health reporter
-lockPref("datareporting.healthreport.service.enabled", {{ .Telemetry }});
-
-// Disable all data upload (Telemetry and FHR)
-lockPref("toolkit.telemetry.enabled", {{ .Telemetry }});
-lockPref("datareporting.policy.dataSubmissionEnabled", {{ .Telemetry }});
-
+{{ end -}}
+{{ if .DisableCrashReporter -}}
 // Disable crash reporter
 lockPref("toolkit.crashreporter.enabled", false);
-
-// Set enigmail GnuPG agent path
-pref("extensions.enigmail.agentPath", "{{ .GnuPgAgentPath }}");
+{{ end -}}
 `))
 	if err := mozillaCfgTpl.Execute(mozillaCfgFile, mozillaCfgData); err != nil {
+		mozillaCfgFile.Close()
 		log.Fatal().Err(err).Msg("Cannot write portapps.cfg")
+	}
+	if err := mozillaCfgFile.Close(); err != nil {
+		log.Fatal().Err(err).Msg("Cannot close portapps.cfg")
 	}
 
 	// Fix extensions path
@@ -248,43 +223,108 @@ func checkLocale() (string, error) {
 	return cfg.Locale, nil
 }
 
-func createPolicies() error {
+func createPolicies(locale string) error {
 	appFile := filepath.Join(utl.CreateFolder(app.AppPath, "distribution"), "policies.json")
 	dataFile := filepath.Join(app.DataPath, "policies.json")
-	defaultPolicies := struct {
-		Policies map[string]interface{} `json:"policies"`
-	}{
-		Policies: map[string]interface{}{
-			"DisableAppUpdate":        true,
-			"DontCheckDefaultBrowser": true,
-		},
+	jsonPolicies := map[string]interface{}{
+		"policies": map[string]interface{}{},
 	}
-
-	jsonPolicies, err := gabs.Consume(defaultPolicies)
+	defaultPolicies, err := json.Marshal(jsonPolicies)
 	if err != nil {
-		return errors.Wrap(err, "Cannot consume default policies")
+		return errors.Wrap(err, "Cannot marshal default policies")
 	}
-	log.Debug().Msgf("Default policies: %s", jsonPolicies.String())
+	log.Debug().Msgf("Default policies: %s", string(defaultPolicies))
 
 	if utl.Exists(dataFile) {
 		rawCustomPolicies, err := os.ReadFile(dataFile)
 		if err != nil {
 			return errors.Wrap(err, "Cannot read custom policies")
 		}
-
-		jsonPolicies, err = gabs.ParseJSON(rawCustomPolicies)
-		if err != nil {
+		if err := json.Unmarshal(rawCustomPolicies, &jsonPolicies); err != nil {
 			return errors.Wrap(err, "Cannot consume custom policies")
 		}
-		log.Debug().Msgf("Custom policies: %s", jsonPolicies.String())
-
-		jsonPolicies.Set(true, "policies", "DisableAppUpdate")
-		jsonPolicies.Set(true, "policies", "DontCheckDefaultBrowser")
+		customPolicies, err := json.Marshal(jsonPolicies)
+		if err != nil {
+			return errors.Wrap(err, "Cannot marshal custom policies")
+		}
+		log.Debug().Msgf("Custom policies: %s", string(customPolicies))
 	}
 
-	log.Debug().Msgf("Applied policies: %s", jsonPolicies.String())
-	err = os.WriteFile(appFile, []byte(jsonPolicies.StringIndent("", "  ")), 0644)
+	managedPrefs := map[string]struct {
+		Value  interface{}
+		Status string
+	}{
+		"calendar.integration.notify": {
+			Value:  false,
+			Status: "locked",
+		},
+		"mail.shell.checkDefaultClient": {
+			Value:  false,
+			Status: "locked",
+		},
+		"mail.winsearch.enable": {
+			Value:  false,
+			Status: "locked",
+		},
+		"mail.winsearch.firstRunDone": {
+			Value:  true,
+			Status: "locked",
+		},
+		"mailnews.start_page.enabled": {
+			Value:  false,
+			Status: "locked",
+		},
+		"mailnews.start_page_override.mstone": {
+			Value:  "ignore",
+			Status: "default",
+		},
+	}
+
+	ensureObject := func(parent map[string]interface{}, key string) (map[string]interface{}, error) {
+		if value, ok := parent[key]; ok {
+			object, ok := value.(map[string]interface{})
+			if !ok {
+				return nil, errors.Errorf("%s must be an object", key)
+			}
+			return object, nil
+		}
+		object := map[string]interface{}{}
+		parent[key] = object
+		return object, nil
+	}
+
+	policies, err := ensureObject(jsonPolicies, "policies")
 	if err != nil {
+		return errors.Wrap(err, "Cannot consume policies")
+	}
+	preferences, err := ensureObject(policies, "Preferences")
+	if err != nil {
+		return errors.Wrap(err, "Cannot consume preferences policies")
+	}
+
+	policies["DisableAppUpdate"] = true
+
+	if cfg.DisableTelemetry {
+		policies["DisableTelemetry"] = true
+	}
+	if locale != "" {
+		policies["RequestedLocales"] = locale
+	}
+	for name, pref := range managedPrefs {
+		preference, err := ensureObject(preferences, name)
+		if err != nil {
+			return err
+		}
+		preference["Value"] = pref.Value
+		preference["Status"] = pref.Status
+	}
+
+	appliedPolicies, err := json.MarshalIndent(jsonPolicies, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "Cannot marshal policies")
+	}
+	log.Debug().Msgf("Applied policies: %s", string(appliedPolicies))
+	if err := os.WriteFile(appFile, appliedPolicies, 0644); err != nil {
 		return errors.Wrap(err, "Cannot write policies")
 	}
 
@@ -292,7 +332,7 @@ func createPolicies() error {
 }
 
 func updateAddonStartup(profileFolder string) error {
-	lz4File := path.Join(profileFolder, "addonStartup.json.lz4")
+	lz4File := filepath.Join(profileFolder, "addonStartup.json.lz4")
 	if !utl.Exists(lz4File) || app.Prev.RootPath == "" {
 		return nil
 	}


### PR DESCRIPTION
- Modernized Thunderbird configuration by moving update, telemetry, locale, and locked preferences to Policies.
- Reduced configuration to portable fallback preferences and optional OpenPGP GnuPG settings.
- Added `disable_crash_reporter` configuration, with crash reporting still disabled by default.
- Added `gnupg_home` configuration and reuse the existing `GNUPGHOME` environment variable when it is not set.
- Added `gnupg_path` configuration for Thunderbird's external OpenPGP GnuPG executable.
- Removed legacy `gnupg_agent_path` and Enigmail-specific configuration.
- Stopped embedding GnuPG in the application build.
- Removed legacy Thunderbird extension scope and add-on compatibility preferences.
- Removed unsupported `DontCheckDefaultBrowser` policy usage.